### PR TITLE
Missing assetsDir

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ In masks you can use next placeholders:
 
 * `:themeDir:` - contains theme dir path
 * `:assetsDir:` - contains assets dir path for create temp copy into public directory. In templates
-now you can use `{$assestDir}` variable as base path for scripts, styles and etc... files
+now you can use `{$assetsDir}` variable as base path for scripts, styles and etc... files
 * `:presenter:` - contains presenter name (without modules)
 * `:modules:` - contains module name (module name My:Module will be replaced to My/Module)
 * `:module_(number):` - contains module name (My:Module => module_1 = My, module_2 => Module)

--- a/src/DI/ThemesManagerExtension.php
+++ b/src/DI/ThemesManagerExtension.php
@@ -73,6 +73,7 @@ class ThemesManagerExtension extends CompilerExtension
 			$templateConfigurator = new Statement('Kappa\ThemesManager\Template\TemplateConfigurator', [
 				array_merge($configuration['parameters'], [
 					'themeDir' => realpath($configuration['themeDir']),
+					'assetsDir' => realpath($configuration['assetsDir'])
 				]),
 				$configuration['helpers'],
 				$configuration['macros']

--- a/src/Template/TemplateConfigurator.php
+++ b/src/Template/TemplateConfigurator.php
@@ -113,6 +113,7 @@ class TemplateConfigurator
 	{
 		foreach ($this->getParameters() as $name => $value) {
 			$value = str_replace(":themeDir:", $this->getParameter('themeDir'), $value);
+			$value = str_replace(":assetsDir:", $this->getParameter('assetsDir'), $value);
 			$template->add($name, $value);
 		}
 		foreach ($this->getHelpers() as $name => $helper) {


### PR DESCRIPTION
Added missing `$assetsDir` param to templates & fixed substitution of :assetsDir: in entire param: section.
